### PR TITLE
Fixed levelup sound not working

### DIFF
--- a/addons/source-python/plugins/wcs/wcs.py
+++ b/addons/source-python/plugins/wcs/wcs.py
@@ -86,6 +86,7 @@ from .core.config import cfg_rested_xp_offline_duration
 from .core.config import cfg_welcome_text
 from .core.config import cfg_welcome_gui_text
 from .core.config import cfg_level_up_effect
+from .core.config import cfg_level_up_sound
 from .core.config import cfg_rank_gain_effect
 from .core.config import cfg_spawn_text
 from .core.config import cfg_hinttext_cooldown


### PR DESCRIPTION
Since the import was missing I kept getting this exception on levelups:

```
 [SP] Caught an Exception:
Traceback (most recent call last):
  File "../addons/source-python/plugins/wcs/wcs.py", line 1138, in on_player_level_up
    if cfg_level_up_sound.get_int():
NameError: name 'cfg_level_up_sound' is not defined

```
This fixes the issue and now the sounds work. This has been tested on CSGO